### PR TITLE
💩 Rudimentarily getting the lib to compile by stubbing add_index_file…

### DIFF
--- a/filecastalogue/src/files/indexes/drivers/local.rs
+++ b/filecastalogue/src/files/indexes/drivers/local.rs
@@ -31,7 +31,8 @@ impl<
 
     fn add_index_file(self: &mut Self, index_file: &(dyn RepoIndexFile))
     -> FcResult<&mut(dyn IndexFileCollection)> {
-        Ok(self.handler.)
+        // Ok(self.handler.)
+        todo!()
     }
 
     fn get_index_file<'ifile>(self: &mut Self, index: &str)

--- a/filecastalogue/src/opaque_collection_handlers.rs
+++ b/filecastalogue/src/opaque_collection_handlers.rs
@@ -154,7 +154,8 @@ impl OpaqueCollectionHandler for LocalDir
         match path.exists() {
             true => Ok(T::new(path)),
             false => Err(error!(
-                ErrorKind::
+                ErrorKind::CollectionHandlerOperationFailed,
+                "Getting a file from the collection."
             ))
         }
         


### PR DESCRIPTION
… and rudimentarily finishing the error for getting a file from an opaque collection handler.